### PR TITLE
Update Vuer.vue

### DIFF
--- a/src/Vuer.vue
+++ b/src/Vuer.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="slider"
-    v-finger:singleTap="handleTapClose">
+    @click="handleTapClose">
     <div class="item-wrapper"
       v-transform
       v-finger:pressMove="handlePressMove"


### PR DESCRIPTION
When I click the picture to exit, the event will pass through, and the elements under the floating layer will also be clicked. Especially on QQ and WeChat.When I changed it to @click, I got better.