### PR TITLE
FIX: 当图片宽高均小于屏幕的时候无法滑动到下一张图

### DIFF
--- a/src/VuerSingle.vue
+++ b/src/VuerSingle.vue
@@ -82,6 +82,7 @@ export default {
       if (this.isSmall) {
         el.translateX += e.deltaX / 3
         el.translateY += e.deltaY / 3
+        this.$emit('enableSwipe')
         return
       }
 


### PR DESCRIPTION
修复当图片宽高均小于屏幕，且属于多张图片可滑动时，无法滑动到下一张图的问题