### PR TITLE
fix: 修复当前页面滚动条不在页面顶部时双击放大图片图片位置异常的问题

### DIFF
--- a/src/VuerSingle.vue
+++ b/src/VuerSingle.vue
@@ -165,8 +165,8 @@ export default {
         this.reset()
       } else {
         let box = el.getBoundingClientRect()
-        let y = window.innerHeight / 2 - e.changedTouches[0].pageY
-        let x = window.innerWidth / 2 - e.changedTouches[0].pageX
+        let y = window.innerHeight / 2 - e.changedTouches[0].clientY
+        let x = window.innerWidth / 2 - e.changedTouches[0].clientX
         new To(el, 'scaleX', this.initialScale * 2, 500, this.ease)
         new To(el, 'scaleY', this.initialScale * 2, 500, this.ease)
         new To(el, 'translateX', x, 500, this.ease)
@@ -200,7 +200,7 @@ export default {
   display: none;
 }
 /* hack issue 16
-   TranslateZ also works as it is a hack to add hardware acceleration to the animation 
+   TranslateZ also works as it is a hack to add hardware acceleration to the animation
    reference https://stackoverflow.com/questions/14677490/blurry-text-after-using-css-transform-scale-in-chrome
 */
 /* img {


### PR DESCRIPTION
复现步骤：去除App.vue中的scroller组件后向下滚动页面，使页面滚动条不在页面顶部 → 点击预览图片 → 双击放大图片